### PR TITLE
DTS-65988

### DIFF
--- a/connectors/webservice/translator-ws/pom.xml
+++ b/connectors/webservice/translator-ws/pom.xml
@@ -39,7 +39,13 @@
         <dependency>
           <groupId>jakarta.activation</groupId>
           <artifactId>jakarta.activation-api</artifactId>
-        </dependency>        
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-core</artifactId>
+            <version>${version.org.apache.cxf}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/wildfly/connectors/webservice/feature-pack-ws/src/main/resources/modules/system/layers/dv/org/jboss/teiid/translator/ws/main/module.xml
+++ b/wildfly/connectors/webservice/feature-pack-ws/src/main/resources/modules/system/layers/dv/org/jboss/teiid/translator/ws/main/module.xml
@@ -16,6 +16,7 @@
         <module name="org.jboss.teiid.api" />
         <module name="com.googlecode.json-simple" />
         <module name="javax.wsdl4j.api"/>
-        <module name="org.springframework.spring" optional="true"/>  
+        <module name="org.springframework.spring" optional="true"/>
+        <module name="org.apache.cxf"/>
     </dependencies>
 </module>


### PR DESCRIPTION
When using WSSecurity to connect to a secure webservice the logs begin to fill with errors resolving cxf.xml. Correct this problem by installing the CXF module classloader as a thread context classloader before the dispatch.