### PR TITLE
Reference caffeine v2.8.5 to fix the integration test issues.

### DIFF
--- a/wildfly/cache-infinispan/pom.xml
+++ b/wildfly/cache-infinispan/pom.xml
@@ -80,6 +80,7 @@
 		<dependency>
 			<groupId>com.github.ben-manes.caffeine</groupId>
 			<artifactId>caffeine</artifactId>
+			<version>2.8.5</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
This should be temporary until we move past Wildfly v21.0