### PR TITLE
Migrate wildfly versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         <version.xerces>2.12.0</version.xerces>
         <version.org.slf4j>1.7.29</version.org.slf4j>
         
-        <version.caffeine>2.8.0</version.caffeine>
+        <version.caffeine>2.8.5</version.caffeine>
         <version.org.checkerframework>2.10.0</version.org.checkerframework>
         
         <version.org.apache.cxf>3.3.6</version.org.apache.cxf>

--- a/wildfly/cache-infinispan/pom.xml
+++ b/wildfly/cache-infinispan/pom.xml
@@ -80,7 +80,6 @@
 		<dependency>
 			<groupId>com.github.ben-manes.caffeine</groupId>
 			<artifactId>caffeine</artifactId>
-			<version>2.8.5</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Update caffeine version to v2.8.5 to fix failing SessionAware cache issues.