### PR TITLE
Update the Spring library versions to 5.3.20

### DIFF
--- a/connectors/webservice/ws-cxf/pom.xml
+++ b/connectors/webservice/ws-cxf/pom.xml
@@ -162,21 +162,25 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
+            <version>${version.org.springframework}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
+            <version>${version.org.springframework}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
+            <version>${version.org.springframework}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-aop</artifactId>
+            <version>${version.org.springframework}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -188,6 +192,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-tx</artifactId>
+            <version>${version.org.springframework}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Update the Spring library versions to 5.3.20 to resolve CVE-2022-22963 and CVE-2022-22965.